### PR TITLE
Add special case for bot messages

### DIFF
--- a/src/backup.js
+++ b/src/backup.js
@@ -175,18 +175,29 @@ class Backup {
       for (let messageIdx = messages.length - 1; messageIdx >= 0; messageIdx--) {
         const message = messages[messageIdx];
 
-        await fsAPI.write(fd, `<div class="message ${message.from.user.id === myId ? 'message-right' : 'message-left'}">
+        // message sent by a user
+        if (message.from.user != null) {
+            await fsAPI.write(fd, `<div class="message ${message.from.user.id === myId ? 'message-right' : 'message-left'}">
   <div class="message-timestamp">${message.lastModifiedDateTime || message.createdDateTime}</div>
   <div class="message-sender">${message.from.user.displayName}</div>
 `);
 
-        if (message.body.contentType === 'html') {
-          await fsAPI.write(fd, `<div class="message-body">${replaceImages(message.body.content, imageIndex)}</div>
+            if (message.body.contentType === 'html') {
+                await fsAPI.write(fd, `<div class="message-body">${replaceImages(message.body.content, imageIndex)}</div>
+</div>`);
+              } else {
+                await fsAPI.write(fd, `<div class="message-body">${escapeHtml(message.body.content)}</div>
+</div>`);
+              }
+        // message sent by a bot
+        } else if (message.from.application != null) {
+            await fsAPI.write(fd, `<div class="message message-left">
+<div class="message-timestamp">${message.lastModifiedDateTime || message.createdDateTime}</div>
+<div class="message-sender">${message.from.application.displayName}</div>
 </div>`);
         } else {
-          await fsAPI.write(fd, `<div class="message-body">${escapeHtml(message.body.content)}</div>
-</div>`);
-        }
+            console.error('couldn\'t determine message sender');
+        }       
       }
     }
 


### PR DESCRIPTION
When the html file is being created, do not write any message tags if it written by a bot ("application" is the terminology used internally). Previously, the script would crash because it expected to be able to access a user id which does not exist in such a situation.